### PR TITLE
fix: Correct sidebar anchor targets

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -3,8 +3,8 @@
   initVideoModal()
   if (PAGE_TYPE) {
     initVersionSelect()
-    initSubHeaders()
     initApiSpecLinks()
+    initSubHeaders()
     initLocationHashFuzzyMatching()
   }
 


### PR DESCRIPTION
Change function execution order to correct sidebar anchor targets; more concise fix to https://github.com/vuejs/vuejs.org/pull/1348.